### PR TITLE
Rename queue_name variable to queue_key

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/ConfigInterface.php
@@ -10,8 +10,8 @@ interface ConfigInterface
     public function getAdapterFactoryConfig();
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      * @return array
      */
-    public function getQueueConfig($queue_name);
+    public function getQueueConfig($queue_key);
 }

--- a/src/Hodor/MessageQueue/Adapter/FactoryInterface.php
+++ b/src/Hodor/MessageQueue/Adapter/FactoryInterface.php
@@ -5,14 +5,14 @@ namespace Hodor\MessageQueue\Adapter;
 interface FactoryInterface
 {
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      * @return ConsumerInterface
      */
-    public function getConsumer($queue_name);
+    public function getConsumer($queue_key);
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      * @return ProducerInterface
      */
-    public function getProducer($queue_name);
+    public function getProducer($queue_key);
 }

--- a/src/Hodor/MessageQueue/Consumer.php
+++ b/src/Hodor/MessageQueue/Consumer.php
@@ -25,34 +25,34 @@ class Consumer
     }
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      * @return ConsumerQueue
      */
-    public function getQueue($queue_name)
+    public function getQueue($queue_key)
     {
-        if (isset($this->consumer_queues[$queue_name])) {
-            return $this->consumer_queues[$queue_name];
+        if (isset($this->consumer_queues[$queue_key])) {
+            return $this->consumer_queues[$queue_key];
         }
 
-        $this->checkQueueName($queue_name);
+        $this->checkQueueKey($queue_key);
 
-        $this->consumer_queues[$queue_name] = new ConsumerQueue(function (callable $callback) use ($queue_name) {
-            $this->consume($queue_name, $callback);
+        $this->consumer_queues[$queue_key] = new ConsumerQueue(function (callable $callback) use ($queue_key) {
+            $this->consume($queue_key, $callback);
         });
 
-        return $this->consumer_queues[$queue_name];
+        return $this->consumer_queues[$queue_key];
     }
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      * @param callable $callback to use for handling the message
      */
-    private function consume($queue_name, callable $callback)
+    private function consume($queue_key, callable $callback)
     {
         $start_time = time();
         $message_count = 0;
 
-        $consumer = $this->adapter_factory->getConsumer($queue_name);
+        $consumer = $this->adapter_factory->getConsumer($queue_key);
 
         $max_message_count = $consumer->getMaxMessagesPerConsume();
         $max_time = $consumer->getMaxTimePerConsume();
@@ -64,10 +64,10 @@ class Consumer
     }
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      */
-    private function checkQueueName($queue_name)
+    private function checkQueueKey($queue_key)
     {
-        $this->adapter_factory->getConsumer($queue_name);
+        $this->adapter_factory->getConsumer($queue_key);
     }
 }

--- a/src/Hodor/MessageQueue/Producer.php
+++ b/src/Hodor/MessageQueue/Producer.php
@@ -36,22 +36,22 @@ class Producer
     }
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      * @return ProducerQueue
      */
-    public function getQueue($queue_name)
+    public function getQueue($queue_key)
     {
-        if (isset($this->producer_queues[$queue_name])) {
-            return $this->producer_queues[$queue_name];
+        if (isset($this->producer_queues[$queue_key])) {
+            return $this->producer_queues[$queue_key];
         }
 
-        $this->checkQueueName($queue_name);
+        $this->checkQueueKey($queue_key);
 
-        $this->producer_queues[$queue_name] = new ProducerQueue(function ($message) use ($queue_name) {
-            $this->push($queue_name, $message);
+        $this->producer_queues[$queue_key] = new ProducerQueue(function ($message) use ($queue_key) {
+            $this->push($queue_key, $message);
         });
 
-        return $this->producer_queues[$queue_name];
+        return $this->producer_queues[$queue_key];
     }
 
     public function beginBatch()
@@ -69,8 +69,8 @@ class Producer
             throw new Exception("The queue is not in transaction.");
         }
 
-        foreach ($this->batches as $queue_name => $batch) {
-            $this->adapter_factory->getProducer($queue_name)->produceMessageBatch($batch);
+        foreach ($this->batches as $queue_key => $batch) {
+            $this->adapter_factory->getProducer($queue_key)->produceMessageBatch($batch);
         }
 
         $this->is_in_batch = false;
@@ -88,24 +88,24 @@ class Producer
     }
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      * @param mixed $message
      */
-    private function push($queue_name, $message)
+    private function push($queue_key, $message)
     {
         if ($this->is_in_batch) {
-            $this->batches[$queue_name][] = new OutgoingMessage($message);
+            $this->batches[$queue_key][] = new OutgoingMessage($message);
             return;
         }
 
-        $this->adapter_factory->getProducer($queue_name)->produceMessage(new OutgoingMessage($message));
+        $this->adapter_factory->getProducer($queue_key)->produceMessage(new OutgoingMessage($message));
     }
 
     /**
-     * @param string $queue_name
+     * @param string $queue_key
      */
-    private function checkQueueName($queue_name)
+    private function checkQueueKey($queue_key)
     {
-        $this->adapter_factory->getProducer($queue_name);
+        $this->adapter_factory->getProducer($queue_key);
     }
 }


### PR DESCRIPTION
The variable was called queue_name but represents
something that may not match the queue name that is
passed to RabbitMQ. The variable is being renamed for
the sake of clarity.