### PR TITLE
Add PHP 7.1 to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 services:
   - rabbitmq


### PR DESCRIPTION
PHP 7.1 should still work since Hodor tests past in PHP 7.1