### PR TITLE
Separate producer and consumer channels

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
@@ -41,18 +41,37 @@ class ChannelFactory
      * @param  string $queue_key
      * @return Channel
      */
-    public function getChannel($queue_key)
+    public function getConsumerChannel($queue_key)
     {
-        if (isset($this->channels[$queue_key])) {
-            return $this->channels[$queue_key];
+        return $this->getChannel('consumer', $queue_key);
+    }
+
+    /**
+     * @param  string $queue_key
+     * @return Channel
+     */
+    public function getProducerChannel($queue_key)
+    {
+        return $this->getChannel('producer', $queue_key);
+    }
+
+    /**
+     * @param  string $queue_key
+     * @param  string $use
+     * @return Channel
+     */
+    private function getChannel($use, $queue_key)
+    {
+        if (isset($this->channels["{$use}:{$queue_key}"])) {
+            return $this->channels["{$use}:{$queue_key}"];
         }
 
         $queue_config = $this->getQueueConfig($queue_key);
         $connection = $this->getConnection($queue_config);
 
-        $this->channels[$queue_key] = new Channel($connection, $queue_config);
+        $this->channels["{$use}:{$queue_key}"] = new Channel($connection, $queue_config);
 
-        return $this->channels[$queue_key];
+        return $this->channels["{$use}:{$queue_key}"];
     }
 
     /**

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
@@ -80,7 +80,7 @@ class Consumer implements ConsumerInterface
             return $this->channel;
         }
 
-        $this->channel = $this->channel_factory->getChannel($this->queue_key);
+        $this->channel = $this->channel_factory->getConsumerChannel($this->queue_key);
 
         return $this->channel;
     }

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Producer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Producer.php
@@ -88,7 +88,7 @@ class Producer implements ProducerInterface
             return $this->channel;
         }
 
-        $this->channel = $this->channel_factory->getChannel($this->queue_key);
+        $this->channel = $this->channel_factory->getProducerChannel($this->queue_key);
 
         return $this->channel;
     }


### PR DESCRIPTION
If the same queue is being consumed from and pushed to during the same
process, they should be using a separate channel but sharing a
connection is ok.