### PR TITLE
Rename channel manager variable to be consistent

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Factory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Factory.php
@@ -17,7 +17,7 @@ class Factory implements FactoryInterface
     /**
      * @var ChannelFactory
      */
-    private $channel_manager;
+    private $channel_factory;
 
     /**
      * @var Consumer[]
@@ -69,11 +69,11 @@ class Factory implements FactoryInterface
 
     public function disconnectAll()
     {
-        if (!$this->channel_manager) {
+        if (!$this->channel_factory) {
             return;
         }
 
-        $this->channel_manager->disconnectAll();
+        $this->channel_factory->disconnectAll();
     }
 
     /**
@@ -81,12 +81,12 @@ class Factory implements FactoryInterface
      */
     private function getChannelFactory()
     {
-        if ($this->channel_manager) {
-            return $this->channel_manager;
+        if ($this->channel_factory) {
+            return $this->channel_factory;
         }
 
-        $this->channel_manager = new ChannelFactory($this->config);
+        $this->channel_factory = new ChannelFactory($this->config);
 
-        return $this->channel_manager;
+        return $this->channel_factory;
     }
 }


### PR DESCRIPTION
The object is called channel factory everywhere else, and I think
'channel manager' is a relic from the past