### PR TITLE
Move queue declaration out of the Channel object

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
@@ -15,7 +15,7 @@ class Channel
     /**
      * @var array
      */
-    private $queue_config;
+    private $channel_config;
 
     /**
      * @var AMQPChannel
@@ -24,21 +24,19 @@ class Channel
 
     /**
      * @param Connection $connection
-     * @param array $queue_config
+     * @param array $channel_config
      */
-    public function __construct(Connection $connection, array $queue_config)
+    public function __construct(Connection $connection, array $channel_config)
     {
         $this->connection = $connection;
-        $this->queue_config = array_merge(
+        $this->channel_config = array_merge(
             [
                 'fetch_count'              => 1,
                 'max_messages_per_consume' => 1,
                 'max_time_per_consume'     => 600,
             ],
-            $queue_config
+            $channel_config
         );
-
-        $this->validateConfig();
     }
 
     /**
@@ -51,17 +49,9 @@ class Channel
         }
 
         $this->amqp_channel = $this->connection->getAmqpConnection()->channel();
-
-        $this->amqp_channel->queue_declare(
-            $this->queue_config['queue_name'],
-            false,
-            ($is_durable = true),
-            false,
-            false
-        );
         $this->amqp_channel->basic_qos(
             null,
-            $this->queue_config['fetch_count'],
+            $this->channel_config['fetch_count'],
             null
         );
 
@@ -69,19 +59,11 @@ class Channel
     }
 
     /**
-     * @return mixed
-     */
-    public function getQueueName()
-    {
-        return $this->queue_config['queue_name'];
-    }
-
-    /**
      * @return int
      */
     public function getMaxMessagesPerConsume()
     {
-        return $this->queue_config['max_messages_per_consume'];
+        return $this->channel_config['max_messages_per_consume'];
     }
 
     /**
@@ -89,18 +71,6 @@ class Channel
      */
     public function getMaxTimePerConsume()
     {
-        return $this->queue_config['max_time_per_consume'];
-    }
-
-    /**
-     * @throws LogicException
-     */
-    private function validateConfig()
-    {
-        foreach (['queue_name'] as $key) {
-            if (empty($this->queue_config[$key])) {
-                throw new LogicException("The connection config must contain a '{$key}' config.");
-            }
-        }
+        return $this->channel_config['max_time_per_consume'];
     }
 }

--- a/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
@@ -30,6 +30,14 @@ class ChannelFactory
         $this->config = $config;
     }
 
+    /**
+     * @return ConfigInterface
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
     public function disconnectAll()
     {
         foreach ($this->connections as $connection) {
@@ -38,7 +46,7 @@ class ChannelFactory
     }
 
     /**
-     * @param  string $queue_key
+     * @param string $queue_key
      * @return Channel
      */
     public function getConsumerChannel($queue_key)
@@ -47,7 +55,7 @@ class ChannelFactory
     }
 
     /**
-     * @param  string $queue_key
+     * @param string $queue_key
      * @return Channel
      */
     public function getProducerChannel($queue_key)

--- a/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategy.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategy.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+use LogicException;
+
+class DeliveryStrategy
+{
+    /**
+     * @var Channel
+     */
+    private $channel;
+
+    /**
+     * @var array
+     */
+    private $queue_config;
+
+    /**
+     * @var bool
+     */
+    private $is_initialized = false;
+
+    /**
+     * @param Channel $channel
+     * @param array $queue_config
+     */
+    public function __construct(Channel $channel, array $queue_config)
+    {
+        $this->channel = $channel;
+        $this->queue_config = $queue_config;
+
+        $this->validateConfig();
+    }
+
+    /**
+     * @return Channel
+     */
+    public function getChannel()
+    {
+        if ($this->is_initialized) {
+            return $this->channel;
+        }
+
+        $this->initialize();
+
+        return $this->channel;
+    }
+
+    /**
+     * @return string
+     */
+    public function getQueueName()
+    {
+        return $this->queue_config['queue_name'];
+    }
+
+    private function initialize()
+    {
+        $this->channel->getAmqpChannel()->queue_declare(
+            $this->queue_config['queue_name'],
+            false,
+            ($is_durable = true),
+            false,
+            false
+        );
+
+        $this->is_initialized = true;
+    }
+
+    /**
+     * @throws LogicException
+     */
+    private function validateConfig()
+    {
+        foreach (['queue_name'] as $key) {
+            if (empty($this->queue_config[$key])) {
+                throw new LogicException("The channel config must contain a '{$key}' config.");
+            }
+        }
+    }
+}

--- a/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+class DeliveryStrategyFactory
+{
+    /**
+     * @var ChannelFactory
+     */
+    private $channel_factory;
+
+    /**
+     * @var DeliveryStrategy[]
+     */
+    private $delivery_strategy = [];
+
+    /**
+     * @param ChannelFactory $channel_factory
+     */
+    public function __construct(ChannelFactory $channel_factory)
+    {
+        $this->channel_factory = $channel_factory;
+    }
+
+    /**
+     * @param string $queue_key
+     * @return DeliveryStrategy
+     */
+    public function getConsumerStrategy($queue_key)
+    {
+        return $this->getStrategy('consumer', $queue_key);
+    }
+
+    /**
+     * @param string $queue_key
+     * @return DeliveryStrategy
+     */
+    public function getProducerStrategy($queue_key)
+    {
+        return $this->getStrategy('producer', $queue_key);
+    }
+
+    /**
+     * @param string $use
+     * @param string $queue_key
+     * @return DeliveryStrategy
+     */
+    private function getStrategy($use, $queue_key)
+    {
+        $cache_key = "{$use}:{$queue_key}";
+
+        if (isset($this->delivery_strategy[$cache_key])) {
+            return $this->delivery_strategy[$cache_key];
+        }
+
+        $this->delivery_strategy[$cache_key] = new DeliveryStrategy(
+            $this->getChannel($use, $queue_key),
+            $this->channel_factory->getConfig()->getQueueConfig($queue_key)
+        );
+
+        return $this->delivery_strategy[$cache_key];
+    }
+
+    /**
+     * @param string $use
+     * @param string $queue_key
+     * @return Channel
+     */
+    private function getChannel($use, $queue_key)
+    {
+        if ('producer' === $use) {
+            return $this->channel_factory->getProducerChannel($queue_key);
+        }
+
+        return $this->channel_factory->getConsumerChannel($queue_key);
+    }
+}

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Factory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Factory.php
@@ -20,6 +20,11 @@ class Factory implements FactoryInterface
     private $channel_factory;
 
     /**
+     * @var DeliveryStrategyFactory
+     */
+    private $delivery_strategy_factory;
+
+    /**
      * @var Consumer[]
      */
     private $consumers = [];
@@ -47,7 +52,7 @@ class Factory implements FactoryInterface
             return $this->consumers[$queue_key];
         }
 
-        $this->consumers[$queue_key] = new Consumer($queue_key, $this->getChannelFactory());
+        $this->consumers[$queue_key] = new Consumer($queue_key, $this->getDeliveryStrategy());
 
         return $this->consumers[$queue_key];
     }
@@ -62,7 +67,7 @@ class Factory implements FactoryInterface
             return $this->producers[$queue_key];
         }
 
-        $this->producers[$queue_key] = new Producer($queue_key, $this->getChannelFactory());
+        $this->producers[$queue_key] = new Producer($queue_key, $this->getDeliveryStrategy());
 
         return $this->producers[$queue_key];
     }
@@ -77,16 +82,17 @@ class Factory implements FactoryInterface
     }
 
     /**
-     * @return ChannelFactory
+     * @return DeliveryStrategyFactory
      */
-    private function getChannelFactory()
+    private function getDeliveryStrategy()
     {
-        if ($this->channel_factory) {
-            return $this->channel_factory;
+        if ($this->delivery_strategy_factory) {
+            return $this->delivery_strategy_factory;
         }
 
         $this->channel_factory = new ChannelFactory($this->config);
+        $this->delivery_strategy_factory = new DeliveryStrategyFactory($this->channel_factory);
 
-        return $this->channel_factory;
+        return $this->delivery_strategy_factory;
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactoryTest.php
@@ -13,6 +13,21 @@ class ChannelFactoryTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @covers ::__construct
+     * @covers ::getConfig
+     * @covers ::<private>
+     */
+    public function testConfigPassedInIsSameConfigRetrieved()
+    {
+        $queues = $this->getTestQueues();
+        $config = $this->getTestConfig($queues);
+
+        $channel_factory = new ChannelFactory($config);
+
+        $this->assertSame($config, $channel_factory->getConfig());
+    }
+
+    /**
+     * @covers ::__construct
      * @covers ::getConsumerChannel
      * @covers ::<private>
      */
@@ -22,10 +37,9 @@ class ChannelFactoryTest extends PHPUnit_Framework_TestCase
         $config = $this->getTestConfig($queues);
 
         $channel_factory = new ChannelFactory($config);
-        foreach ($queues as $queue_key => $queue_config) {
+        foreach (array_keys($queues) as $queue_key) {
             $channel = $channel_factory->getConsumerChannel($queue_key);
             $this->assertInstanceOf('Hodor\MessageQueue\Adapter\Amqp\Channel', $channel);
-            $this->assertEquals($queue_config['queue_name'], $channel->getQueueName());
         }
     }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelTest.php
@@ -12,18 +12,6 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::__construct
      * @covers ::<private>
-     * @dataProvider provideQueueConfigMissingARequiredField
-     * @expectedException \LogicException
-     * @param array $queue_config
-     */
-    public function testExceptionIsThrownIfARequiredFieldIsMissing(array $queue_config)
-    {
-        new Channel($this->getMockConnection(), $queue_config);
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::<private>
      */
     public function testConnectionCanBeInstantiatedWithoutError()
     {
@@ -65,20 +53,6 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::getQueueName
-     */
-    public function testQueueNamePassedToConstructorIsTheSameRetrieved()
-    {
-        $queue_name = uniqid();
-
-        $connection = $this->getMockConnection();
-        $channel = new Channel($connection, ['queue_name' => $queue_name]);
-
-        $this->assertEquals($queue_name, $channel->getQueueName());
-    }
-
-    /**
-     * @covers ::__construct
      * @covers ::getMaxMessagesPerConsume
      */
     public function testMaxMessagesPerConsumePassedToConstructorIsTheSameRetrieved()
@@ -109,26 +83,6 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         ]);
 
         $this->assertEquals($max_time, $channel->getMaxTimePerConsume());
-    }
-
-    /**
-     * @return array
-     */
-    public function provideQueueConfigMissingARequiredField()
-    {
-        $required_fields = [
-            'queue_name' => uniqid(),
-        ];
-
-        $queue_configs = [];
-        foreach (array_keys($required_fields) as $field_to_remove) {
-            $queue_config = $required_fields;
-            unset($queue_config[$field_to_remove]);
-
-            $queue_configs[] = [$queue_config];
-        }
-
-        return $queue_configs;
     }
 
     /**

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
@@ -37,8 +37,8 @@ class ConsumerTest extends BaseConsumerTest
      */
     protected function getTestConsumer(array $config_overrides = [])
     {
-        $channel_factory = $this->generateChannelFactory($this->getTestConfig($config_overrides));
-        $test_consumer = new Consumer('fast_jobs', $channel_factory);
+        $strategy_factory = $this->generateStrategyFactory($this->getTestConfig($config_overrides));
+        $test_consumer = new Consumer('fast_jobs', $strategy_factory);
 
         return $test_consumer;
     }
@@ -48,23 +48,23 @@ class ConsumerTest extends BaseConsumerTest
      */
     protected function produceMessage(OutgoingMessage $message)
     {
-        $channel_factory = $this->generateChannelFactory($this->getTestConfig());
-        $producer = new Producer('fast_jobs', $channel_factory);
+        $strategy_factory = $this->generateStrategyFactory($this->getTestConfig());
+        $producer = new Producer('fast_jobs', $strategy_factory);
 
         $producer->produceMessage($message);
     }
 
     /**
      * @param Config $config
-     * @return ChannelFactory
+     * @return DeliveryStrategyFactory
      */
-    private function generateChannelFactory(Config $config)
+    private function generateStrategyFactory(Config $config)
     {
         $channel_factory = new ChannelFactory($config);
 
         $this->channel_factories[] = $channel_factory;
 
-        return $channel_factory;
+        return new DeliveryStrategyFactory($channel_factory);
     }
 
     /**

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyFactoryTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+use Hodor\MessageQueue\Adapter\Testing\Config;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\Adapter\Amqp\DeliveryStrategyFactory
+ */
+class DeliveryStrategyFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getProducerStrategy
+     * @covers ::getConsumerStrategy
+     * @covers ::<private>
+     */
+    public function testStrategyFactoryReturnsStrategiesWithConfiguredQueueNames()
+    {
+        $queues = $this->getTestQueues();
+        $strategy_factory = $this->getTestStrategyFactory($queues);
+
+        $this->assertSame(
+            $queues['fast_jobs']['queue_name'],
+            $strategy_factory->getProducerStrategy('fast_jobs')->getQueueName()
+        );
+        $this->assertSame(
+            $queues['slow_jobs']['queue_name'],
+            $strategy_factory->getConsumerStrategy('slow_jobs')->getQueueName()
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getProducerStrategy
+     * @covers ::getConsumerStrategy
+     * @covers ::<private>
+     */
+    public function testStrategiesAreReused()
+    {
+        $strategy_factory = $this->getTestStrategyFactory();
+
+        $this->assertSame(
+            $strategy_factory->getProducerStrategy('fast_jobs'),
+            $strategy_factory->getProducerStrategy('fast_jobs')
+        );
+        $this->assertSame(
+            $strategy_factory->getConsumerStrategy('slow_jobs'),
+            $strategy_factory->getConsumerStrategy('slow_jobs')
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getProducerStrategy
+     * @covers ::getConsumerStrategy
+     * @covers ::<private>
+     */
+    public function testStrategyFactoryUsesSameChannelFactoryPassedToConstructor()
+    {
+        $queues = $this->getTestQueues();
+        $config = $this->getTestConfig($queues);
+
+        $channel_factory = new ChannelFactory($config);
+        $strategy_factory = new DeliveryStrategyFactory($channel_factory);
+
+        $this->assertSame(
+            $channel_factory->getProducerChannel('fast_jobs'),
+            $strategy_factory->getProducerStrategy('fast_jobs')->getChannel()
+        );
+        $this->assertSame(
+            $channel_factory->getConsumerChannel('slow_jobs'),
+            $strategy_factory->getConsumerStrategy('slow_jobs')->getChannel()
+        );
+    }
+
+    /**
+     * @param array|null $queues
+     * @return DeliveryStrategyFactory
+     */
+    private function getTestStrategyFactory(array $queues = null)
+    {
+        if (!$queues) {
+            $queues = $this->getTestQueues();
+        }
+        $config = $this->getTestConfig($queues);
+
+        $channel_factory = new ChannelFactory($config);
+        return new DeliveryStrategyFactory($channel_factory);
+    }
+
+    /**
+     * @param array $queues
+     * @return Config
+     */
+    private function getTestConfig(array $queues)
+    {
+        $config_provider = new ConfigProvider($this);
+
+        return $config_provider->getConfigAdapter($queues);
+    }
+
+    /**
+     * @return array
+     */
+    private function getTestQueues()
+    {
+        $config_provider = new ConfigProvider($this);
+
+        return [
+            'fast_jobs' => $config_provider->getQueueConfig(),
+            'slow_jobs' => $config_provider->getQueueConfig(),
+        ];
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Hodor\MessageQueue\Adapter\Amqp;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass Hodor\MessageQueue\Adapter\Amqp\DeliveryStrategy
+ */
+class DeliveryStrategyTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::<private>
+     * @dataProvider provideQueueConfigMissingARequiredField
+     * @expectedException \LogicException
+     * @param array $queue_config
+     */
+    public function testExceptionIsThrownIfARequiredFieldIsMissing(array $queue_config)
+    {
+        new DeliveryStrategy($this->getMockChannel(), $queue_config);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getQueueName
+     * @covers ::<private>
+     */
+    public function testQueueNamePassedToConstructorIsTheSameRetrieved()
+    {
+        $queue_name = uniqid();
+        $channel = $this->getMockChannel();
+        $strategy = new DeliveryStrategy($channel, ['queue_name' => $queue_name]);
+        $this->assertEquals($queue_name, $strategy->getQueueName());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getChannel
+     * @covers ::<private>
+     * @dataProvider provideQueueList
+     * @param array $queues
+     */
+    public function testChannelsCanBeRetrieved(array $queues)
+    {
+        foreach ($queues as $queue_config) {
+            $connection = new Connection($queue_config);
+            $channel = new Channel($connection, $queue_config);
+            $strategy = new DeliveryStrategy($channel, $queue_config);
+            $this->assertInstanceOf(
+                'Hodor\MessageQueue\Adapter\Amqp\Channel',
+                $strategy->getChannel()
+            );
+        }
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getChannel
+     * @covers ::<private>
+     * @dataProvider provideQueueList
+     * @param array $queues
+     */
+    public function testChannelsCanBeReused(array $queues)
+    {
+        foreach ($queues as $queue_config) {
+            $connection = new Connection($queue_config);
+            $channel = new Channel($connection, $queue_config);
+            $strategy = new DeliveryStrategy($channel, $queue_config);
+            $this->assertSame($strategy->getChannel(), $strategy->getChannel());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function provideQueueConfigMissingARequiredField()
+    {
+        $required_fields = [
+            'queue_name' => uniqid(),
+        ];
+
+        $queue_configs = [];
+        foreach (array_keys($required_fields) as $field_to_remove) {
+            $queue_config = $required_fields;
+            unset($queue_config[$field_to_remove]);
+
+            $queue_configs[] = [$queue_config];
+        }
+
+        return $queue_configs;
+    }
+
+    /**
+     * @return array
+     */
+    public function provideQueueList()
+    {
+        $config_provider = new ConfigProvider($this);
+
+        return [
+            [
+                [
+                    'fast_jobs' => $config_provider->getQueueConfig(),
+                    'slow_jobs' => $config_provider->getQueueConfig(),
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @return Channel
+     */
+    private function getMockChannel()
+    {
+        return $this
+            ->getMockBuilder('Hodor\MessageQueue\Adapter\Amqp\Channel')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
@@ -37,8 +37,8 @@ class ProducerTest extends BaseProducerTest
      */
     protected function getTestProducer(array $config_overrides = [])
     {
-        $channel_factory = $this->generateChannelFactory($this->getTestConfig($config_overrides));
-        $test_producer = new Producer('fast_jobs', $channel_factory);
+        $strategy_factory = $this->generateStrategyFactory($this->getTestConfig($config_overrides));
+        $test_producer = new Producer('fast_jobs', $strategy_factory);
 
         return $test_producer;
     }
@@ -48,8 +48,8 @@ class ProducerTest extends BaseProducerTest
      */
     protected function consumeMessage()
     {
-        $channel_factory = $this->generateChannelFactory($this->getTestConfig());
-        $consumer = new Consumer('fast_jobs', $channel_factory);
+        $strategy_factory = $this->generateStrategyFactory($this->getTestConfig());
+        $consumer = new Consumer('fast_jobs', $strategy_factory);
 
         $consumer->consumeMessage(function (IncomingMessage $message) use (&$return) {
             $return = $message->getContent();
@@ -58,22 +58,24 @@ class ProducerTest extends BaseProducerTest
 
         // disconnect after consuming so the unused channel does not prefetch
         // and hold a message unack'd while another channel is looking for it
-        $channel_factory->disconnectAll();
+        foreach ($this->channel_factories as $channel_factory) {
+            $channel_factory->disconnectAll();
+        }
 
         return $return;
     }
 
     /**
      * @param Config $config
-     * @return ChannelFactory
+     * @return DeliveryStrategyFactory
      */
-    private function generateChannelFactory(Config $config)
+    private function generateStrategyFactory(Config $config)
     {
         $channel_factory = new ChannelFactory($config);
 
         $this->channel_factories[] = $channel_factory;
 
-        return $channel_factory;
+        return new DeliveryStrategyFactory($channel_factory);
     }
 
     /**


### PR DESCRIPTION
The queue declaration is being moved out of the Channel object into new
DeliveryStrategy objects. This should help:

 - Progress the efforts to re-use channels for multiple queues
 - Open the door for allowing delivery strategy to be customized, such
   as declaring exchanges and allowing for the exchange to fanout a
   message to multiple queues