### PR TITLE
Use the same channel for multiple queues

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Channel.php
@@ -52,7 +52,7 @@ class Channel
         $this->amqp_channel->basic_qos(
             null,
             $this->channel_config['fetch_count'],
-            null
+            false
         );
 
         return $this->amqp_channel;

--- a/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactory.php
@@ -70,16 +70,18 @@ class ChannelFactory
      */
     private function getChannel($use, $queue_key)
     {
-        if (isset($this->channels["{$use}:{$queue_key}"])) {
-            return $this->channels["{$use}:{$queue_key}"];
+        $queue_config = $this->getQueueConfig($queue_key);
+        $channel_key = $this->getChannelKey($use, $queue_config);
+
+        if (isset($this->channels[$channel_key])) {
+            return $this->channels[$channel_key];
         }
 
-        $queue_config = $this->getQueueConfig($queue_key);
         $connection = $this->getConnection($queue_config);
 
-        $this->channels["{$use}:{$queue_key}"] = new Channel($connection, $queue_config);
+        $this->channels[$channel_key] = new Channel($connection, $queue_config);
 
-        return $this->channels["{$use}:{$queue_key}"];
+        return $this->channels[$channel_key];
     }
 
     /**
@@ -136,7 +138,25 @@ class ChannelFactory
                 $queue_config['host'],
                 $queue_config['port'],
                 $queue_config['username'],
-                $queue_config['queue_name'],
+            ]
+        );
+    }
+
+    /**
+     * @param string $use
+     * @param array $queue_config
+     * @return string
+     */
+    private function getChannelKey($use, array $queue_config)
+    {
+        return implode(
+            '::',
+            [
+                $this->getConnectionKey($queue_config),
+                $use,
+                $queue_config['fetch_count'],
+                $queue_config['max_messages_per_consume'],
+                $queue_config['max_time_per_consume'],
             ]
         );
     }

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelFactoryTest.php
@@ -79,6 +79,22 @@ class ChannelFactoryTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::__construct
      * @covers ::getConsumerChannel
+     * @covers ::<private>
+     */
+    public function testChannelsAreReusedIfSameChannelSettingsAreUsed()
+    {
+        $config = $this->getTestConfig($this->getTestQueues());
+
+        $channel_factory = new ChannelFactory($config);
+        $this->assertSame(
+            $channel_factory->getConsumerChannel('fast_jobs'),
+            $channel_factory->getConsumerChannel('slow_jobs')
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getConsumerChannel
      * @covers ::getProducerChannel
      * @covers ::<private>
      */


### PR DESCRIPTION
Instead of using a new channel for every queue, use one channel per set
of channel options provided via the queue configuration.

Issue #9