### PR TITLE
Remove an unused variable

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
@@ -54,7 +54,7 @@ class Consumer implements ConsumerInterface
             $this->getDeliveryStrategy()->getQueueName(),
             '',
             false,
-            ($auto_ack = false),
+            false,
             false,
             false,
             function ($amqp_message) use ($callback) {

--- a/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategy.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategy.php
@@ -60,7 +60,7 @@ class DeliveryStrategy
         $this->channel->getAmqpChannel()->queue_declare(
             $this->queue_config['queue_name'],
             false,
-            ($is_durable = true),
+            true,
             false,
             false
         );


### PR DESCRIPTION
The variable was being used to make the name of the corresponding
parameter obvious, but that's what we have IDEs for. Plus, I was not
being consistent with that with the other parameter names.