### PR TITLE
Reduce scope of consumer/producer's dependencies

### DIFF
--- a/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Consumer.php
@@ -10,28 +10,16 @@ use PhpAmqpLib\Exception\AMQPTimeoutException;
 class Consumer implements ConsumerInterface
 {
     /**
-     * @var string
-     */
-    private $queue_key;
-
-    /**
-     * @var DeliveryStrategyFactory
-     */
-    private $strategy_factory;
-
-    /**
      * @var DeliveryStrategy
      */
     private $delivery_strategy;
 
     /**
-     * @param string $queue_key
-     * @param DeliveryStrategyFactory $strategy_factory
+     * @param DeliveryStrategy $delivery_strategy
      */
-    public function __construct($queue_key, DeliveryStrategyFactory $strategy_factory)
+    public function __construct(DeliveryStrategy $delivery_strategy)
     {
-        $this->queue_key = $queue_key;
-        $this->strategy_factory = $strategy_factory;
+        $this->delivery_strategy = $delivery_strategy;
     }
 
     /**
@@ -75,14 +63,6 @@ class Consumer implements ConsumerInterface
      */
     private function getDeliveryStrategy()
     {
-        if ($this->delivery_strategy) {
-            return $this->delivery_strategy;
-        }
-
-        $this->delivery_strategy = $this->strategy_factory->getProducerStrategy(
-            $this->queue_key
-        );
-
         return $this->delivery_strategy;
     }
 

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Factory.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Factory.php
@@ -52,7 +52,8 @@ class Factory implements FactoryInterface
             return $this->consumers[$queue_key];
         }
 
-        $this->consumers[$queue_key] = new Consumer($queue_key, $this->getDeliveryStrategy());
+        $delivery_strategy = $this->getDeliveryStrategyFactory()->getConsumerStrategy($queue_key);
+        $this->consumers[$queue_key] = new Consumer($delivery_strategy);
 
         return $this->consumers[$queue_key];
     }
@@ -67,7 +68,8 @@ class Factory implements FactoryInterface
             return $this->producers[$queue_key];
         }
 
-        $this->producers[$queue_key] = new Producer($queue_key, $this->getDeliveryStrategy());
+        $delivery_strategy = $this->getDeliveryStrategyFactory()->getProducerStrategy($queue_key);
+        $this->producers[$queue_key] = new Producer($delivery_strategy);
 
         return $this->producers[$queue_key];
     }
@@ -84,7 +86,7 @@ class Factory implements FactoryInterface
     /**
      * @return DeliveryStrategyFactory
      */
-    private function getDeliveryStrategy()
+    private function getDeliveryStrategyFactory()
     {
         if ($this->delivery_strategy_factory) {
             return $this->delivery_strategy_factory;

--- a/src/Hodor/MessageQueue/Adapter/Amqp/Producer.php
+++ b/src/Hodor/MessageQueue/Adapter/Amqp/Producer.php
@@ -10,28 +10,16 @@ use RuntimeException;
 class Producer implements ProducerInterface
 {
     /**
-     * @var string
-     */
-    private $queue_key;
-
-    /**
-     * @var DeliveryStrategyFactory
-     */
-    private $strategy_factory;
-
-    /**
      * @var DeliveryStrategy
      */
     private $delivery_strategy;
 
     /**
-     * @param string $queue_key
-     * @param DeliveryStrategyFactory $strategy_factory
+     * @param DeliveryStrategy $delivery_strategy
      */
-    public function __construct($queue_key, DeliveryStrategyFactory $strategy_factory)
+    public function __construct(DeliveryStrategy $delivery_strategy)
     {
-        $this->queue_key = $queue_key;
-        $this->strategy_factory = $strategy_factory;
+        $this->delivery_strategy = $delivery_strategy;
     }
 
     /**
@@ -84,14 +72,6 @@ class Producer implements ProducerInterface
      */
     private function getDeliveryStrategy()
     {
-        if ($this->delivery_strategy) {
-            return $this->delivery_strategy;
-        }
-
-        $this->delivery_strategy = $this->strategy_factory->getProducerStrategy(
-            $this->queue_key
-        );
-
         return $this->delivery_strategy;
     }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
@@ -38,7 +38,7 @@ class ConsumerTest extends BaseConsumerTest
     protected function getTestConsumer(array $config_overrides = [])
     {
         $strategy_factory = $this->generateStrategyFactory($this->getTestConfig($config_overrides));
-        $test_consumer = new Consumer('fast_jobs', $strategy_factory);
+        $test_consumer = new Consumer($strategy_factory->getConsumerStrategy('fast_jobs'));
 
         return $test_consumer;
     }
@@ -49,7 +49,7 @@ class ConsumerTest extends BaseConsumerTest
     protected function produceMessage(OutgoingMessage $message)
     {
         $strategy_factory = $this->generateStrategyFactory($this->getTestConfig());
-        $producer = new Producer('fast_jobs', $strategy_factory);
+        $producer = new Producer($strategy_factory->getProducerStrategy('fast_jobs'));
 
         $producer->produceMessage($message);
     }

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ProducerTest.php
@@ -38,7 +38,7 @@ class ProducerTest extends BaseProducerTest
     protected function getTestProducer(array $config_overrides = [])
     {
         $strategy_factory = $this->generateStrategyFactory($this->getTestConfig($config_overrides));
-        $test_producer = new Producer('fast_jobs', $strategy_factory);
+        $test_producer = new Producer($strategy_factory->getProducerStrategy('fast_jobs'));
 
         return $test_producer;
     }
@@ -49,7 +49,7 @@ class ProducerTest extends BaseProducerTest
     protected function consumeMessage()
     {
         $strategy_factory = $this->generateStrategyFactory($this->getTestConfig());
-        $consumer = new Consumer('fast_jobs', $strategy_factory);
+        $consumer = new Consumer($strategy_factory->getConsumerStrategy('fast_jobs'));
 
         $consumer->consumeMessage(function (IncomingMessage $message) use (&$return) {
             $return = $message->getContent();


### PR DESCRIPTION
Instead of the consumer and producer requiring a DeliveryStrategyFactory
and queue name, retrieve and pass only the designated queue's
DeliveryStrategy into the consumer/producer