### PR TITLE
Add RabbitMQ development environment setup tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ PHP library for connecting to RabbitMQ
  - PHP >= 5.5.18
  - Composer
  - RabbitMQ
+
+## Development Env Tips
+
+ - Set test RabbitMQ queues to automatically delete after 10 minutes
+    ```
+    rabbitmqctl set_policy expire-test-hodor "test-hodor-.*" '{"expires":600000}' --apply-to queues
+    ```


### PR DESCRIPTION
Until I have a better dev environment, add a command to set a RabbitMQ
policy that automatically clears out test queues after they have gone
unused or 10 minutes