### PR TITLE
Set Rabbit queues to delete after 10 minutes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: '3.3'
 services:
   rabbitmq:
-    user: 'rabbitmq'
-    image: rabbitmq:3.6-management
+    build: docker/services/rabbitmq
     restart: always
     ports:
       - 5672

--- a/docker/services/rabbitmq/Dockerfile
+++ b/docker/services/rabbitmq/Dockerfile
@@ -1,0 +1,4 @@
+FROM rabbitmq:3.6-management
+MAINTAINER Matt Light <matt.light@lightdatasys.com>
+
+COPY docker/fs /

--- a/docker/services/rabbitmq/docker/fs/etc/rabbitmq/rabbitmq.config
+++ b/docker/services/rabbitmq/docker/fs/etc/rabbitmq/rabbitmq.config
@@ -1,0 +1,15 @@
+[
+    { rabbit, [
+        { loopback_users, [ ] },
+        { tcp_listeners, [ 5672 ] },
+        { ssl_listeners, [ ] },
+        { hipe_compile, false }
+    ] },
+    { rabbitmq_management, [
+        { listener, [
+            { port, 15672 },
+            { ssl, false }
+        ] },
+        {load_definitions, "/etc/rabbitmq/rabbitmq_definitions.json"}
+    ] }
+].

--- a/docker/services/rabbitmq/docker/fs/etc/rabbitmq/rabbitmq_definitions.json
+++ b/docker/services/rabbitmq/docker/fs/etc/rabbitmq/rabbitmq_definitions.json
@@ -1,0 +1,40 @@
+{
+    "users": [
+        {
+            "name": "guest",
+            "password_hash": "Q24e80/0+e8OMOj7ehnRROe3c9hgpJZr8k/FeSiRIVl/jigC",
+            "hashing_algorithm": "rabbit_password_hashing_sha256",
+            "tags": "administrator"
+        }
+    ],
+    "vhosts": [
+        {
+            "name": "/"
+        }
+    ],
+    "permissions": [
+        {
+            "user": "guest",
+            "vhost": "/",
+            "configure": ".*",
+            "write": ".*",
+            "read": ".*"
+        }
+    ],
+    "parameters": [],
+    "global_parameters": [],
+    "policies": [
+        {
+            "vhost": "/",
+            "name": "expire-test-hodor",
+            "pattern": "test-hodor-.*",
+            "definition": {
+                "expires": 600000
+            },
+            "apply-to": "queues"
+        }
+    ],
+    "queues": [],
+    "exchanges": [],
+    "bindings": []
+}


### PR DESCRIPTION
The policy is set in the RabbitMQ config so it does not need to be
manually set after the server starts.

The template for rabbitmq_definitions.json was generated using:
```bash
./rabbitmqadmin export rabbitmq_definitions.json
```

rabbitmqadmin was downloaded from
https://www.rabbitmq.com/management-cli.html