### PR TITLE
Make php container depend on rabbitmq container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,11 @@ RUN apt-get update -qq \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug
 
-ADD https://getcomposer.org/installer composer-setup.php
-RUN php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
+ADD https://getcomposer.org/installer /usr/local/bin/composer-setup.php
+RUN php /usr/local/bin/composer-setup.php \
+    --quiet \
+    --install-dir=/usr/local/bin \
+    --filename=composer
 
 COPY docker/fs /
 COPY . /ravens

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,12 @@ RUN php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=compo
 COPY docker/fs /
 COPY . /ravens
 
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
+    /usr/local/bin/wait-for-it.sh
+
+RUN chmod 0755 /usr/local/bin/*.sh
+
 VOLUME [ "/ravens" ]
 WORKDIR /ravens
 
-ENTRYPOINT ["bash", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["bash", "/usr/local/bin/entrypoint.sh", "docker"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-test:
-	docker-compose run --rm php test
-
-install:
-	docker-compose run --rm php install

--- a/configure
+++ b/configure
@@ -6,7 +6,7 @@ case "$1" in
         ;;
 
     shell)
-        CMD_PREFIX='bash docker/fs/usr/local/bin/entrypoint.sh'
+        CMD_PREFIX='bash docker/fs/usr/local/bin/entrypoint.sh shell'
         ;;
 
     bash)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,5 @@ services:
     build: .
     volumes:
       - .:/ravens
+    depends_on:
+      - rabbitmq

--- a/docker/fs/usr/local/bin/entrypoint.sh
+++ b/docker/fs/usr/local/bin/entrypoint.sh
@@ -1,7 +1,35 @@
 #!/bin/bash
 
-case "$1" in
+ENV="${1}"
+COMMAND="${2}"
+
+wait_for_it ()
+{
+    local host=$1
+    local port=$2
+
+    bash /usr/local/bin/wait-for-it.sh -q "${host}:${port}"
+    local exit_code=$?
+    if [ $exit_code -eq 0 ]; then
+        return
+    fi
+
+    echo "Unable to connect to '${host}' port ${port}"
+    exit $exit_code
+}
+
+wait_on_depends ()
+{
+    if [ "docker" != "${ENV}" ]; then
+        return
+    fi
+
+    wait_for_it rabbitmq 5672
+}
+
+case "${COMMAND}" in
     test)
+        wait_on_depends
         php vendor/bin/phpunit
         ;;
 
@@ -20,6 +48,6 @@ case "$1" in
         ;;
 
     *)
-        echo $"Usage: $0 {test|bash}"
+        echo $"Usage: $0 {docker|shell} {test|install|bash}"
         exit 1
 esac


### PR DESCRIPTION
Wait for rabbitmq container to be up and ready before allowing tests
to be ran in the php container