### PR TITLE
Switch RabbitMQ docker to alpine image

### DIFF
--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.6-management
+FROM rabbitmq:3.6-management-alpine
 MAINTAINER Matt Light <matt.light@lightdatasys.com>
 
 COPY docker/rabbitmq/fs /


### PR DESCRIPTION
While developing at a hotel, pulling down debian/ubuntu images is not
the funnest.