### PR TITLE
Dedupe queue config code in tests

### DIFF
--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ChannelTest.php
@@ -24,12 +24,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::__construct
      * @covers ::getAmqpChannel
-     * @dataProvider provideQueueList
-     * @param array $queues
      */
-    public function testAmqpChannelsCanBeRetrieved(array $queues)
+    public function testAmqpChannelsCanBeRetrieved()
     {
-        foreach ($queues as $queue_config) {
+        foreach ($this->getQueueConfigs() as $queue_config) {
             $connection = new Connection($queue_config);
             $channel = new Channel($connection, $queue_config);
             $this->assertInstanceOf('PhpAmqpLib\Channel\AMQPChannel', $channel->getAmqpChannel());
@@ -39,12 +37,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::__construct
      * @covers ::getAmqpChannel
-     * @dataProvider provideQueueList
-     * @param array $queues
      */
-    public function testAmqpChannelsCanBeReused(array $queues)
+    public function testAmqpChannelsCanBeReused()
     {
-        foreach ($queues as $queue_config) {
+        foreach ($this->getQueueConfigs() as $queue_config) {
             $connection = new Connection($queue_config);
             $channel = new Channel($connection, $queue_config);
             $this->assertSame($channel->getAmqpChannel(), $channel->getAmqpChannel());
@@ -54,17 +50,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function provideQueueList()
+    public function getQueueConfigs()
     {
-        $config_provider = new ConfigProvider();
-
         return [
-            [
-                [
-                    'fast_jobs' => $config_provider->getQueueConfig(),
-                    'slow_jobs' => $config_provider->getQueueConfig(),
-                ]
-            ]
+            'q_one' => ConfigProvider::getQueueConfig(),
+            'q_two' => ConfigProvider::getQueueConfig(),
         ];
     }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
@@ -11,11 +11,17 @@ class ConfigProvider
      * @param array $config_overrides
      * @return Config
      */
-    public function getConfigAdapter(array $queues, array $config_overrides = [])
+    public static function getConfigAdapter(array $queues, array $config_overrides = [])
     {
         $config = new Config([]);
         foreach ($queues as $queue_key => $queue_config) {
-            $config->addQueueConfig($queue_key, array_merge($queue_config, $config_overrides));
+            if (is_string($queue_config)) {
+                $queue_key = $queue_config;
+                $queue_config = self::getQueueConfig();
+            }
+
+            $queue_config = array_merge($queue_config, $config_overrides);
+            $config->addQueueConfig($queue_key, $queue_config);
         }
 
         return $config;
@@ -24,9 +30,9 @@ class ConfigProvider
     /**
      * @return array
      */
-    public function getQueueConfig()
+    public static function getQueueConfig()
     {
-        $rabbit_credentials = $this->getRabbitCredentials();
+        $rabbit_credentials = self::getRabbitCredentials();
 
         return [
             'host'       => $rabbit_credentials['host'],
@@ -40,10 +46,10 @@ class ConfigProvider
     /**
      * @return array
      */
-    private function getRabbitCredentials()
+    private static function getRabbitCredentials()
     {
         $config = require __DIR__ . '/../../../../../../config/config.test.php';
 
-        return  $config['test']['rabbitmq'];
+        return $config['test']['rabbitmq'];
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConfigProvider.php
@@ -8,10 +8,9 @@ class ConfigProvider
 {
     /**
      * @param array $queues
-     * @param array $config_overrides
      * @return Config
      */
-    public static function getConfigAdapter(array $queues, array $config_overrides = [])
+    public static function getConfigAdapter(array $queues)
     {
         $config = new Config([]);
         foreach ($queues as $queue_key => $queue_config) {
@@ -20,7 +19,6 @@ class ConfigProvider
                 $queue_config = self::getQueueConfig();
             }
 
-            $queue_config = array_merge($queue_config, $config_overrides);
             $config->addQueueConfig($queue_key, $queue_config);
         }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/ConsumerTest.php
@@ -22,6 +22,13 @@ class ConsumerTest extends BaseConsumerTest
      */
     private $config;
 
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->config = ConfigProvider::getConfigAdapter(['only_q']);
+    }
+
     public function tearDown()
     {
         parent::tearDown();
@@ -32,13 +39,12 @@ class ConsumerTest extends BaseConsumerTest
     }
 
     /**
-     * @param array $config_overrides
      * @return ConsumerInterface
      */
-    protected function getTestConsumer(array $config_overrides = [])
+    protected function getTestConsumer()
     {
-        $strategy_factory = $this->generateStrategyFactory($this->getTestConfig($config_overrides));
-        $test_consumer = new Consumer($strategy_factory->getConsumerStrategy('fast_jobs'));
+        $strategy_factory = $this->generateStrategyFactory();
+        $test_consumer = new Consumer($strategy_factory->getConsumerStrategy('only_q'));
 
         return $test_consumer;
     }
@@ -48,50 +54,21 @@ class ConsumerTest extends BaseConsumerTest
      */
     protected function produceMessage(OutgoingMessage $message)
     {
-        $strategy_factory = $this->generateStrategyFactory($this->getTestConfig());
-        $producer = new Producer($strategy_factory->getProducerStrategy('fast_jobs'));
+        $strategy_factory = $this->generateStrategyFactory();
+        $producer = new Producer($strategy_factory->getProducerStrategy('only_q'));
 
         $producer->produceMessage($message);
     }
 
     /**
-     * @param Config $config
      * @return DeliveryStrategyFactory
      */
-    private function generateStrategyFactory(Config $config)
+    private function generateStrategyFactory()
     {
-        $channel_factory = new ChannelFactory($config);
+        $channel_factory = new ChannelFactory($this->config);
 
         $this->channel_factories[] = $channel_factory;
 
         return new DeliveryStrategyFactory($channel_factory);
-    }
-
-    /**
-     * @param array $config_overrides
-     * @return Config
-     */
-    private function getTestConfig(array $config_overrides = [])
-    {
-        if ($this->config) {
-            return $this->config;
-        }
-
-        $config_provider = new ConfigProvider();
-        $test_queues = $this->getTestQueues($config_provider);
-        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
-
-        return $this->config;
-    }
-
-    /**
-     * @param ConfigProvider $config_provider
-     * @return array
-     */
-    private function getTestQueues(ConfigProvider $config_provider)
-    {
-        return [
-            'fast_jobs' => $config_provider->getQueueConfig(),
-        ];
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/DeliveryStrategyTest.php
@@ -38,12 +38,10 @@ class DeliveryStrategyTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::getChannel
      * @covers ::<private>
-     * @dataProvider provideQueueList
-     * @param array $queues
      */
-    public function testChannelsCanBeRetrieved(array $queues)
+    public function testChannelsCanBeRetrieved()
     {
-        foreach ($queues as $queue_config) {
+        foreach ($this->getQueueConfigs() as $queue_config) {
             $connection = new Connection($queue_config);
             $channel = new Channel($connection, $queue_config);
             $strategy = new DeliveryStrategy($channel, $queue_config);
@@ -58,12 +56,10 @@ class DeliveryStrategyTest extends PHPUnit_Framework_TestCase
      * @covers ::__construct
      * @covers ::getChannel
      * @covers ::<private>
-     * @dataProvider provideQueueList
-     * @param array $queues
      */
-    public function testChannelsCanBeReused(array $queues)
+    public function testChannelsCanBeReused()
     {
-        foreach ($queues as $queue_config) {
+        foreach ($this->getQueueConfigs() as $queue_config) {
             $connection = new Connection($queue_config);
             $channel = new Channel($connection, $queue_config);
             $strategy = new DeliveryStrategy($channel, $queue_config);
@@ -94,17 +90,11 @@ class DeliveryStrategyTest extends PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function provideQueueList()
+    public function getQueueConfigs()
     {
-        $config_provider = new ConfigProvider();
-
         return [
-            [
-                [
-                    'fast_jobs' => $config_provider->getQueueConfig(),
-                    'slow_jobs' => $config_provider->getQueueConfig(),
-                ]
-            ]
+            'q_one' => ConfigProvider::getQueueConfig(),
+            'q_two' => ConfigProvider::getQueueConfig(),
         ];
     }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/FactoryTest.php
@@ -48,12 +48,11 @@ class FactoryTest extends BaseFactoryTest
     }
 
     /**
-     * @param array $config_overrides
      * @return Factory
      */
-    protected function getTestFactory(array $config_overrides = [])
+    protected function getTestFactory()
     {
-        $config = ConfigProvider::getConfigAdapter(['only_q'], $config_overrides);
+        $config = ConfigProvider::getConfigAdapter(['only_q']);
         $test_factory = new Factory($config);
 
         $this->factories[] = $test_factory;

--- a/tests/src/Hodor/MessageQueue/Adapter/Amqp/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Amqp/FactoryTest.php
@@ -2,9 +2,7 @@
 
 namespace Hodor\MessageQueue\Adapter\Amqp;
 
-use Hodor\MessageQueue\Adapter\FactoryInterface;
 use Hodor\MessageQueue\Adapter\FactoryTest as BaseFactoryTest;
-use Hodor\MessageQueue\Adapter\Testing\Config;
 
 /**
  * @coversDefaultClass Hodor\MessageQueue\Adapter\Amqp\Factory
@@ -15,11 +13,6 @@ class FactoryTest extends BaseFactoryTest
      * @var Factory[]
      */
     private $factories;
-
-    /**
-     * @var Config
-     */
-    private $config;
 
     public function tearDown()
     {
@@ -48,7 +41,7 @@ class FactoryTest extends BaseFactoryTest
     {
         $test_factory = $this->getTestFactory();
 
-        $test_factory->getProducer('fast_jobs');
+        $test_factory->getProducer('only_q');
         $test_factory->disconnectAll();
 
         $this->assertTrue(true);
@@ -60,38 +53,11 @@ class FactoryTest extends BaseFactoryTest
      */
     protected function getTestFactory(array $config_overrides = [])
     {
-        $test_factory = new Factory($this->getTestConfig($config_overrides));
+        $config = ConfigProvider::getConfigAdapter(['only_q'], $config_overrides);
+        $test_factory = new Factory($config);
 
         $this->factories[] = $test_factory;
 
         return $test_factory;
-    }
-
-    /**
-     * @param array $config_overrides
-     * @return Config
-     */
-    private function getTestConfig(array $config_overrides = [])
-    {
-        if ($this->config) {
-            return $this->config;
-        }
-
-        $config_provider = new ConfigProvider();
-        $test_queues = $this->getTestQueues($config_provider);
-        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
-
-        return $this->config;
-    }
-
-    /**
-     * @param ConfigProvider $config_provider
-     * @return array
-     */
-    private function getTestQueues(ConfigProvider $config_provider)
-    {
-        return [
-            'fast_jobs' => $config_provider->getQueueConfig(),
-        ];
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/ConsumerTest.php
@@ -38,10 +38,9 @@ abstract class ConsumerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array $config_overrides
      * @return ConsumerInterface
      */
-    abstract protected function getTestConsumer(array $config_overrides = []);
+    abstract protected function getTestConsumer();
 
     /**
      * @param OutgoingMessage $message

--- a/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
@@ -59,8 +59,7 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array $config_overrides
      * @return FactoryInterface
      */
-    abstract protected function getTestFactory(array $config_overrides = []);
+    abstract protected function getTestFactory();
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/FactoryTest.php
@@ -20,9 +20,9 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
 
         $factory = $this->getTestFactory();
 
-        $factory->getProducer('fast_jobs')->produceMessage(new OutgoingMessage($unique_message));
+        $factory->getProducer('only_q')->produceMessage(new OutgoingMessage($unique_message));
 
-        $factory->getConsumer('fast_jobs')->consumeMessage(function (IncomingMessage $message) use ($unique_message) {
+        $factory->getConsumer('only_q')->consumeMessage(function (IncomingMessage $message) use ($unique_message) {
             $this->assertEquals($unique_message, $message->getContent());
             $message->acknowledge();
         });
@@ -38,8 +38,8 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
         $factory = $this->getTestFactory();
 
         $this->assertSame(
-            $factory->getProducer('fast_jobs'),
-            $factory->getProducer('fast_jobs')
+            $factory->getProducer('only_q'),
+            $factory->getProducer('only_q')
         );
     }
 
@@ -53,8 +53,8 @@ abstract class FactoryTest extends PHPUnit_Framework_TestCase
         $factory = $this->getTestFactory();
 
         $this->assertSame(
-            $factory->getConsumer('fast_jobs'),
-            $factory->getConsumer('fast_jobs')
+            $factory->getConsumer('only_q'),
+            $factory->getConsumer('only_q')
         );
     }
 

--- a/tests/src/Hodor/MessageQueue/Adapter/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/ProducerTest.php
@@ -2,7 +2,6 @@
 
 namespace Hodor\MessageQueue\Adapter;
 
-use Hodor\MessageQueue\IncomingMessage;
 use Hodor\MessageQueue\OutgoingMessage;
 use PHPUnit_Framework_TestCase;
 
@@ -44,10 +43,9 @@ abstract class ProducerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array $config_overrides
      * @return ProducerInterface
      */
-    abstract protected function getTestProducer(array $config_overrides = []);
+    abstract protected function getTestProducer();
 
     /**
      * @return string $expected_message

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ConsumerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ConsumerTest.php
@@ -13,23 +13,23 @@ use Hodor\MessageQueue\OutgoingMessage;
 class ConsumerTest extends BaseConsumerTest
 {
     /**
-     * @var MessageBank[]
+     * @var MessageBank
      */
-    private $message_banks = [];
+    private $message_bank;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->message_bank = new MessageBank(ConfigProvider::getQueueConfig());
+    }
 
     /**
-     * @var Config
-     */
-    private $config;
-
-    /**
-     * @param array $config_overrides
      * @return ConsumerInterface
      */
-    protected function getTestConsumer(array $config_overrides = [])
+    protected function getTestConsumer()
     {
-        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig($config_overrides));
-        $test_consumer = new Consumer($message_bank);
+        $test_consumer = new Consumer($this->message_bank);
 
         return $test_consumer;
     }
@@ -39,53 +39,8 @@ class ConsumerTest extends BaseConsumerTest
      */
     protected function produceMessage(OutgoingMessage $message)
     {
-        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig());
-        $producer = new Producer($message_bank);
+        $producer = new Producer($this->message_bank);
 
         $producer->produceMessage($message);
-    }
-
-    /**
-     * @param string $queue_key
-     * @param Config $config
-     * @return MessageBank
-     */
-    private function getMessageBank($queue_key, Config $config)
-    {
-        if (!empty($this->message_banks[$queue_key])) {
-            return $this->message_banks[$queue_key];
-        }
-
-        $this->message_banks[$queue_key] = new MessageBank($config->getQueueConfig($queue_key));
-
-        return $this->message_banks[$queue_key];
-    }
-
-    /**
-     * @param array $config_overrides
-     * @return Config
-     */
-    private function getTestConfig(array $config_overrides = [])
-    {
-        if ($this->config) {
-            return $this->config;
-        }
-
-        $config_provider = new ConfigProvider();
-        $test_queues = $this->getTestQueues($config_provider);
-        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
-
-        return $this->config;
-    }
-
-    /**
-     * @param ConfigProvider $config_provider
-     * @return array
-     */
-    private function getTestQueues(ConfigProvider $config_provider)
-    {
-        return [
-            'fast_jobs' => $config_provider->getQueueConfig(),
-        ];
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/FactoryTest.php
@@ -11,11 +11,10 @@ use Hodor\MessageQueue\Adapter\FactoryTest as BaseFactoryTest;
 class FactoryTest extends BaseFactoryTest
 {
     /**
-     * @param array $config_overrides
      * @return Factory
      */
-    protected function getTestFactory(array $config_overrides = [])
+    protected function getTestFactory()
     {
-        return new Factory(ConfigProvider::getConfigAdapter(['only_q'], $config_overrides));
+        return new Factory(ConfigProvider::getConfigAdapter(['only_q']));
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/FactoryTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/FactoryTest.php
@@ -11,44 +11,11 @@ use Hodor\MessageQueue\Adapter\FactoryTest as BaseFactoryTest;
 class FactoryTest extends BaseFactoryTest
 {
     /**
-     * @var Config
-     */
-    private $config;
-
-    /**
      * @param array $config_overrides
      * @return Factory
      */
     protected function getTestFactory(array $config_overrides = [])
     {
-        return new Factory($this->getTestConfig($config_overrides));
-    }
-
-    /**
-     * @param array $config_overrides
-     * @return Config
-     */
-    private function getTestConfig(array $config_overrides = [])
-    {
-        if ($this->config) {
-            return $this->config;
-        }
-
-        $config_provider = new ConfigProvider();
-        $test_queues = $this->getTestQueues($config_provider);
-        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
-
-        return $this->config;
-    }
-
-    /**
-     * @param ConfigProvider $config_provider
-     * @return array
-     */
-    private function getTestQueues(ConfigProvider $config_provider)
-    {
-        return [
-            'fast_jobs' => $config_provider->getQueueConfig(),
-        ];
+        return new Factory(ConfigProvider::getConfigAdapter(['only_q'], $config_overrides));
     }
 }

--- a/tests/src/Hodor/MessageQueue/Adapter/Testing/ProducerTest.php
+++ b/tests/src/Hodor/MessageQueue/Adapter/Testing/ProducerTest.php
@@ -6,7 +6,6 @@ use Hodor\MessageQueue\Adapter\Amqp\ConfigProvider;
 use Hodor\MessageQueue\Adapter\ProducerInterface;
 use Hodor\MessageQueue\Adapter\ProducerTest as BaseProducerTest;
 use Hodor\MessageQueue\IncomingMessage;
-use PHPUnit_Framework_TestCase;
 
 /**
  * @coversDefaultClass Hodor\MessageQueue\Adapter\Testing\Producer
@@ -19,18 +18,11 @@ class ProducerTest extends BaseProducerTest
     private $message_banks = [];
 
     /**
-     * @var Config
-     */
-    private $config;
-
-
-    /**
-     * @param array $config_overrides
      * @return ProducerInterface
      */
-    protected function getTestProducer(array $config_overrides = [])
+    protected function getTestProducer()
     {
-        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig($config_overrides));
+        $message_bank = $this->getMessageBank('only_q');
         $test_producer = new Producer($message_bank);
 
         return $test_producer;
@@ -41,7 +33,7 @@ class ProducerTest extends BaseProducerTest
      */
     protected function consumeMessage()
     {
-        $message_bank = $this->getMessageBank('fast_jobs', $this->getTestConfig());
+        $message_bank = $this->getMessageBank('only_q');
         $consumer = new Consumer($message_bank);
 
         $consumer->consumeMessage(function (IncomingMessage $message) use (&$return) {
@@ -54,45 +46,16 @@ class ProducerTest extends BaseProducerTest
 
     /**
      * @param string $queue_key
-     * @param Config $config
      * @return MessageBank
      */
-    private function getMessageBank($queue_key, Config $config)
+    private function getMessageBank($queue_key)
     {
         if (!empty($this->message_banks[$queue_key])) {
             return $this->message_banks[$queue_key];
         }
 
-        $this->message_banks[$queue_key] = new MessageBank($config->getQueueConfig($queue_key));
+        $this->message_banks[$queue_key] = new MessageBank(ConfigProvider::getQueueConfig());
 
         return $this->message_banks[$queue_key];
-    }
-
-    /**
-     * @param array $config_overrides
-     * @return Config
-     */
-    private function getTestConfig(array $config_overrides = [])
-    {
-        if ($this->config) {
-            return $this->config;
-        }
-
-        $config_provider = new ConfigProvider();
-        $test_queues = $this->getTestQueues($config_provider);
-        $this->config = $config_provider->getConfigAdapter($test_queues, $config_overrides);
-
-        return $this->config;
-    }
-
-    /**
-     * @param ConfigProvider $config_provider
-     * @return array
-     */
-    private function getTestQueues(ConfigProvider $config_provider)
-    {
-        return [
-            'fast_jobs' => $config_provider->getQueueConfig(),
-        ];
     }
 }


### PR DESCRIPTION
There was a lot of boilerplate code in tests to setup queue configs.
This boilerplate code was increasing the work required to add consumer
versus producer queue configs.  It is still not perfect, but this should
be a step in the better direction.